### PR TITLE
Adding the NFC reader path as a variable in usersettings.py

### DIFF
--- a/readnfc.py
+++ b/readnfc.py
@@ -129,7 +129,7 @@ print("")
 print("NFC READER")
 print("Connecting to NFC reader...")
 try:
-    reader = nfc.ContactlessFrontend('usb')
+    reader = nfc.ContactlessFrontend(usersettings.nfc_reader_path)
 except IOError as e:
     print ("... could not connect to reader")
     print ("")

--- a/usersettings.py
+++ b/usersettings.py
@@ -9,3 +9,11 @@ sonosroom=""
 
 #send anonymous usage statistics
 sendanonymoususagestatistics="yes"
+
+#if you are getting erros saying your nfc reader can not be found do the following:
+#type lsusb into a terminal on your raspberry pi and enter
+#in the output, find your nfc reader and copy the hex code next to it
+#(for example, the ACR122U it is 072f:2200)
+#then replace "usb" with "usb:072f:2200"
+#(or whatever lsusb outputted for your nfc reader)
+nfc_reader_path="usb"


### PR DESCRIPTION
**My changes**
I added the NFC reader path as a variable in usersettings.py. This path is used in place of `"usb"` in readnfc.py (however, `"usb"` is still the default path so nothing changes for users who have their code working fine). 
The specific line of code changed is `reader = nfc.ContactlessFrontend(usersettings.nfc_reader_path)` on line 132. 
I also added instructions on how to find the new path in usersettings.py 

**Why did I change this?**
This seems like a common issue so I thought I would add this. I had this issue and so did another member of the [r/vinylemulator](https://www.reddit.com/r/vinylemulator)

**What error does this help fix?**
Sometimes people using vinyl emulator will get an error saying the NFC reader was not found.

**Who am I?**
[u/Esamanoaz](https://www.reddit.com/u/Esamanoaz) on reddit