### PR TITLE
Adding ability to play Sonos Favorites and BBC Sounds radio station streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Examples of what can be passed:
       
       favourite/BBC_Radio_2
 
+      bbcsounds:bbc_radio_two
+
       command:playpause
       command:mute
       command:next

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Examples of what can be passed:
       spotify:user:spotify:playlist:32O0SSXDNWDrMievPkV0Im
 
       tunein/play/44491
+      
+      favourite/BBC_Radio_2
 
       command:playpause
       command:mute

--- a/README.md
+++ b/README.md
@@ -41,9 +41,12 @@ This currently accesses three any of three different services depending on the c
 | ---------------- | --------------- |
 | spotify: | Plays a spotify album, track or playlist URI |
 | tunein: | Plays a radio station identified by a tunein ID number |
-| apple: | Plays a Apple music album, track of playlist URI |
+| bbcsounds: | Plays a BBC radio station identified by stream name as detailed in node-sonos-http-api readme |
+| apple: | Plays a Apple Music album, track or playlist URI |
+| amazonmusic: | Plays a Amazon Music album, track or playlist URI |
 | room: | Changes the room in which the script plays|
 | command: | Executes a command in the current room; can accept any command as defined in node-sonos-http-api |
+| favorite: | Plays a Sonos favorite identified by its name |
 
 Examples of what can be passed:
 

--- a/readnfc.py
+++ b/readnfc.py
@@ -56,7 +56,7 @@ def touched(tag):
                 sonosinstruction = "applemusic/now/" + receivedtext[11:]
 
             if receivedtext_lower.startswith ('bbcsounds:'):
-                servicetype = "bbcSounds"
+                servicetype = "bbcsounds"
                 sonosinstruction = 'bbcsounds/play/' + receivedtext[10:]
 
             #check if a Sonos "command" or room change read from NFC

--- a/readnfc.py
+++ b/readnfc.py
@@ -55,6 +55,10 @@ def touched(tag):
                 servicetype = "applemusic"
                 sonosinstruction = "applemusic/now/" + receivedtext[11:]
 
+            if receivedtext_lower.startswith ('bbcsounds:'):
+                servicetype = "bbcSounds"
+                sonosinstruction = 'bbcsounds/play/' + receivedtext[10:]
+
             #check if a Sonos "command" or room change read from NFC
             if receivedtext_lower.startswith ('command'):
                 servicetype = "command"

--- a/readnfc.py
+++ b/readnfc.py
@@ -39,6 +39,10 @@ def touched(tag):
                 servicetype = "tunein"
                 sonosinstruction = receivedtext
             
+            if receivedtext_lower.startswith ('favorite'):
+                servicetype = "favorite"
+                sonosinstruction = receivedtext
+            
             if receivedtext_lower.startswith ('amazonmusic:'):
                 servicetype = "amazonmusic"
                 sonosinstruction = "amazonmusic/now/" + receivedtext[12:]


### PR DESCRIPTION
These changes  add the ability to play Sonos Favorites using the tag format "favorite/[favorite name]